### PR TITLE
Add placeholder class to mixin to support JS polyfills

### DIFF
--- a/incuna-sass/mixins/_placeholder.sass
+++ b/incuna-sass/mixins/_placeholder.sass
@@ -16,3 +16,6 @@
 
     &::input-placeholder
         @content
+
+    &.placeholder
+        @content


### PR DESCRIPTION
@incuna/frontend This is a tiny modification to apply the placeholder styles to input with a placeholder class, such as those polyfilled by javascript.

e.g. jquery-placeholder polyfills input elements and gives them a class of `placeholder` when they are showing the placeholder text, but currently this text would not be styled the same way as placeholder text in modern browsers.
