### PR TITLE
Add `main` to `display:block;` HTML5 shim.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.2
+* Add `<main>` element to HTML5 `display: block;` shim in the reset.
+
 # 3.1.1
 
 * Removed borders on `input[type="checkbox"]` and `input[type="radio"]`.

--- a/incuna-sass/_reset.sass
+++ b/incuna-sass/_reset.sass
@@ -24,7 +24,7 @@ time, mark, audio, video
 
 // HTML5 display-role reset for older browsers
 article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section
+footer, header, hgroup, main, menu, nav, section
     display: block
 
 body


### PR DESCRIPTION
Without it, iOS 6 and other browsers won't default `<main>` to
block display.

@incuna/frontend Please merge and I'll make a new release. Ta!
