### PR TITLE
Comment on the end of selector causes warning

### DIFF
--- a/incuna-sass/_normalize.sass
+++ b/incuna-sass/_normalize.sass
@@ -151,8 +151,8 @@ select
 // 2. Correct inability to style clickable `input` types in iOS.
 // 3. Improve usability and consistency of cursor style between image-type
 //    `input` and others.
+// 1: The selector `html input[type="button"]`
 button,
-// 1
 html input[type="button"],
 input[type="reset"],
 input[type="submit"]


### PR DESCRIPTION
> WARNING on line 152 of .../incuna-sass/incuna-sass/_normalize.sass:
> This selector doesn't have any properties and will not be rendered.

Sass no likey comment on end of selector. Doesn't seem to mind on the end of a property. But we don't really do comments on end of lines anymore, this one seems a bit overkill anyway.
