### PR TITLE
Round 2x sprite values instead of ceiling them.

### DIFF
--- a/incuna-sass/mixins/_sprites.sass
+++ b/incuna-sass/mixins/_sprites.sass
@@ -1,5 +1,5 @@
 $sprites-1x: sprite-map("1x/sprite-files/*.png", $layout: smart)
-$sprites-2x: sprite-map("2x/sprite-files/*.png", $spacing: 5px)
+$sprites-2x: sprite-map("2x/sprite-files/*.png", $layout: smart)
 
 @mixin sprite-1x
     background:

--- a/incuna-sass/mixins/_sprites.sass
+++ b/incuna-sass/mixins/_sprites.sass
@@ -1,5 +1,5 @@
-$sprites-1x: sprite-map("1x/sprite-files/*.png", $layout: smart)
-$sprites-2x: sprite-map("2x/sprite-files/*.png", $layout: smart)
+$sprites-1x: sprite-map("1x/sprite-files/*.png", $spacing: 2px)
+$sprites-2x: sprite-map("2x/sprite-files/*.png", $spacing: 2px)
 
 @mixin sprite-1x
     background:

--- a/incuna-sass/mixins/_sprites.sass
+++ b/incuna-sass/mixins/_sprites.sass
@@ -32,5 +32,5 @@ $sprites-2x: sprite-map("2x/sprite-files/*.png", $spacing: 5px)
     @include media($hidpi)
         $position: sprite-position($sprites-2x, $name)
         background:
-            position: ceil(nth($position, 1) / 2) ceil(nth($position, 2) / 2)
-        @include background-size(ceil(image-width(sprite-path($sprites-2x)) / 2) auto)
+            position: round(nth($position, 1) / 2) round(nth($position, 2) / 2)
+        @include background-size(round(image-width(sprite-path($sprites-2x)) / 2) auto)

--- a/incuna-sass/mixins/_sprites.sass
+++ b/incuna-sass/mixins/_sprites.sass
@@ -32,5 +32,5 @@ $sprites-2x: sprite-map("2x/sprite-files/*.png", $spacing: 5px)
     @include media($hidpi)
         $position: sprite-position($sprites-2x, $name)
         background:
-            position: round(nth($position, 1) / 2) round(nth($position, 2) / 2)
-        @include background-size(round(image-width(sprite-path($sprites-2x)) / 2) auto)
+            position: ceil(nth($position, 1) / 2) ceil(nth($position, 2) / 2)
+        @include background-size(ceil(image-width(sprite-path($sprites-2x)) / 2) auto)


### PR DESCRIPTION
>Can result in offset positions that end up
cropping the 2x sprite.

@incuna/frontend I had a problem that this fixes. Unsure if it's right though. Please comment.
