### PR TITLE
Improve hidpi media query mixin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.2
+
+* Improve HiDPI media query. Removes dpi units which cause error spam in Chrome's console.
+
 # 4.0.1
 
 * Make 1x and 2x sprite maps consistent, both using 2px spacing.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "incuna-sass",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "homepage": "https://github.com/incuna/incuna-sass",
   "authors": [
     "Perry Roper <perryroper@gmail.com>"

--- a/incuna-sass/mixins/_media.sass
+++ b/incuna-sass/mixins/_media.sass
@@ -2,8 +2,8 @@
     @media #{$expression}
         @content
 
-// HiDPI displays - https://github.com/h5bp/html5-boilerplate/issues/1127 and http://core.trac.wordpress.org/changeset/22629
-$hidpi: "print, (-o-min-device-pixel-ratio: 5/4), (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+// HiDPI displays - https://signalvnoise.com/posts/3271-easy-retina-ready-images-using-scss
+$hidpi: "print, (min--moz-device-pixel-ratio: 1.3), (-o-min-device-pixel-ratio: 2.6/2), (-webkit-min-device-pixel-ratio: 1.3), (min-device-pixel-ratio: 1.3), (min-resolution: 1.3dppx)"
 // Print
 $print: "print"
 


### PR DESCRIPTION
Removes DPI units to resolve an error in Google Chrome

Consider using 'dppx' units, as in CSS 'dpi' means dots-per-CSS-inch, not dots-per-physical-inch, so does not correspond to the actual 'dpi' of a screen.

@incuna/frontend please.