### PR TITLE
use rem funtion without adding px

### DIFF
--- a/incuna-sass/functions/_rem.sass
+++ b/incuna-sass/functions/_rem.sass
@@ -7,4 +7,4 @@ $use-rem: false !default
             @return 0
         @return $target / $context + 0rem
     @else
-        @return $target
+        @return $target + 0px


### PR DESCRIPTION
@incuna/frontend please review

with this small fix it would be possible to use the rem function as it is currently (i.e. `rem(12px)` )
but also like this:
`rem(12)`
which is a bit shorter