### PR TITLE
fixes unicode export char issue

### DIFF
--- a/incuna-sass/legacy/_icomoon.sass
+++ b/incuna-sass/legacy/_icomoon.sass
@@ -14,7 +14,7 @@
 @each $icon in $icomoon-icons
     %icon-#{nth($icon, 1)}
         @extend %legacy-iconmoon-helper
-        content: '\e' + nth($icon, 2)
+        content: unquote("\"\\e#{nth($icon, 2)}\"")
     .lt-ie8 &
         %icon-#{nth($icon, 1)}-ie
             zoom: expression(this.runtimeStyle["zoom"] = "1", this.innerHTML = "&#xe#{nth($icon, 2)};")


### PR DESCRIPTION
Hey, I encountered an issue with the webfonts not being rendered correctly.

The project I'm working on seems to be referencing version 3.1.0 of incuna-sass which is pretty old now, but I have provided a fix in the 'legacy' code section which should resolve this issue in the future.

In the fix I am escaping the backslash character so it works equally on different versions of sass.
