### PR TITLE
add new font-face mixin with less formats required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Upcoming
+
+* Add new font face mixin
+
 # 5.1.3
 
 * Unnest modal styles, remove media queries to make them easier to overwrite

--- a/incuna-sass/mixins/_font-face.sass
+++ b/incuna-sass/mixins/_font-face.sass
@@ -1,0 +1,59 @@
+// New font face mixin with more flexibility and more comprehensive browser support
+// Requires that you set the font file path for the project locally
+// Like this:
+//      @function font-url($path)
+//          @return url('../path/to/fonts/' + $path)
+@mixin font-face($style-name, $file, $family, $category: '', $woff2: false, $IE-8: false)
+    $filepath: $family + '/' + $file
+    @font-face
+        font-family: '#{$style-name}'
+
+        // Default src without IE-8 and woff2 support
+        src: font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+        // Support for woff2 files is optional 
+        // (this format still has quite limited support)
+        @if $woff2
+            src: font-url($filepath + '.woff2') format('woff2'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+        // Support for IE8 and lower requires .eot format
+        @if $IE-8
+            src: font-url($filepath + '.eot'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+        // If both IE-8 and woff2 is required
+        @if $IE-8 and $woff2
+            src: font-url($filepath + '.eot'), font-url($filepath + '.woff2') format('woff2'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+// Use this mixin to set fonts in your project
+@mixin font($style-name, $category: sans-serif)
+    font:
+        family: '#{$style-name}', $category
+        style: normal
+        weight: normal
+
+// I recommend setting font names as variables in your projects locally
+// to make it easier to set fonts, eg:
+
+// $font-main: font-name
+// .main
+//     @include font($font-main)
+
+// for different font-weights and styles:
+
+// $font-bold: font-name-bold
+// $font-medium-italic: font-name-medium-italic
+// .main
+//     h2
+//         @include font($font-bold)
+//     em
+//         @include font($font-medium-italic)
+
+// or for an accent font:
+
+// $font-fancy-script: fancy-script-font-name
+// .fancy-element
+//     @include font($font-fancy-script, cursive)
+
+// $font-formal-serif: formal-serif-font-name
+// .formal-element
+//     @include font($font-formal-serif, serif)

--- a/incuna-sass/mixins/_font-face.sass
+++ b/incuna-sass/mixins/_font-face.sass
@@ -3,33 +3,31 @@
 // Like this:
 //      @function font-url($path)
 //          @return url('../path/to/fonts/' + $path)
-@mixin font-face($style-name, $file, $family, $category: '', $woff2: false, $IE-8: false)
-    $filepath: $family + '/' + $file
-    @font-face
-        font-family: '#{$style-name}'
 
-        // Default src without IE-8 and woff2 support
-        src: font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+// Use the font-face mixin to add web fonts to your projects
+// introduce the arguments in the following manner:
+// @include font-face("font-name", "font-file-name", "folder-name", "font-category")
+// where 
+// font-name = the name you want to use for the font in your project
+// font-file-name = the name of the font file in your project files
+// folder-name = the name of the parent folder containing your font file - usually named 
+//     to match font family name
+// font-category = serif, sans-serif, cursive, etc.
 
-        // Support for woff2 files is optional 
-        // (this format still has quite limited support)
-        @if $woff2
-            src: font-url($filepath + '.woff2') format('woff2'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+// You can use the two optional arguments to add .woff2 and/or .eot formats to your mixin
+// .woff2 is an updated version of .woff and has limited support at the moment
+// .eot is an IE specific format that adds support for IE8 and below
 
-        // Support for IE8 and lower requires .eot format
-        @if $IE-8
-            src: font-url($filepath + '.eot'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+// Fonts of different weights / styles should be added separately
 
-        // If both IE-8 and woff2 is required
-        @if $IE-8 and $woff2
-            src: font-url($filepath + '.eot'), font-url($filepath + '.woff2') format('woff2'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+// for example if you'd like your project to use Roboto across 
+// all browsers:
+//     @include font-face("roboto-regular", "Roboto-Regular", "roboto", "sans-serif")
+//     @include font-face("roboto-medium", "Roboto-Medium", "roboto", "sans-serif")
+//     @include font-face("roboto-bold-italic", "Roboto-Bold-Italic", "roboto", "sans-serif")
 
-// Use this mixin to set fonts in your project
-@mixin font($style-name, $category: sans-serif)
-    font:
-        family: '#{$style-name}', $category
-        style: normal
-        weight: normal
+// You can then use the font mixin to apply these fonts to your elements:
+//     @include font(roboto-regular)
 
 // I recommend setting font names as variables in your projects locally
 // to make it easier to set fonts, eg:
@@ -57,3 +55,31 @@
 // $font-formal-serif: formal-serif-font-name
 // .formal-element
 //     @include font($font-formal-serif, serif)
+
+@mixin font-face($style-name, $file, $family, $category: '', $woff2: false, $IE-8: false)
+    $filepath: $family + '/' + $file
+    @font-face
+        font-family: '#{$style-name}'
+
+        // Default src without IE-8 and woff2 support
+        src: font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+        // Support for woff2 files is optional 
+        // (this format still has quite limited support)
+        @if $woff2
+            src: font-url($filepath + '.woff2') format('woff2'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+        // Support for IE8 and lower requires .eot format
+        @if $IE-8
+            src: font-url($filepath + '.eot'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+        // If both IE-8 and woff2 is required
+        @if $IE-8 and $woff2
+            src: font-url($filepath + '.eot'), font-url($filepath + '.woff2') format('woff2'), font-url($filepath + ".woff") format('woff'), font-url($filepath + ".otf") format('opentype')
+
+// Use this mixin to set fonts in your project
+@mixin font($style-name, $category: sans-serif)
+    font:
+        family: '#{$style-name}', $category
+        style: normal
+        weight: normal


### PR DESCRIPTION
basic support should be available with .woff and .otf formats, .eot is an optional extra for IE8 and below, and .woff2 can be added optionally for modern browsers

this also means we won't need to `@extend` fonts anymore and overwriting them should therefore be much easier

@incuna/frontend please review (I've tested it locally in a project and it seems to work fine)