### PR TITLE
update helpers to use mixins with optional extends

### DIFF
--- a/incuna-sass/_helpers.sass
+++ b/incuna-sass/_helpers.sass
@@ -1,8 +1,4 @@
-@import helpers/box-sizing
-@import helpers/clearfix
 @import helpers/image-replace
 @import helpers/link
 @import helpers/overflow-scroll
-@import helpers/pseudo-elements
-@import helpers/vertical-center
 @import helpers/visually-hidden

--- a/incuna-sass/_legacy.sass
+++ b/incuna-sass/_legacy.sass
@@ -4,3 +4,4 @@
 @import legacy/icomoon
 @import legacy/pseudo-elements
 @import legacy/rgba-background
+@import legacy/vertical-center

--- a/incuna-sass/_mixins.sass
+++ b/incuna-sass/_mixins.sass
@@ -1,8 +1,4 @@
-@import mixins/font-face
 @import mixins/media
-@import mixins/placeholder
-@import mixins/rgba-background
-@import mixins/svg-background
 @import mixins/svg
 // Sprites mixin will cause errors if sprite folders are not set up
 // @import mixins/sprites

--- a/incuna-sass/helpers/_image-replace.sass
+++ b/incuna-sass/helpers/_image-replace.sass
@@ -1,11 +1,15 @@
 // Use this helper when replacing text with an image in a block level element
-%image-replace
+@mixin image-replace
     background:
         color: transparent
     border: 0
     overflow: hidden
+    &::before,
     &:before
         content: ''
         display: block
         width: 0
         height: 100%
+
+%image-replace
+    @include image-replace

--- a/incuna-sass/helpers/_link.sass
+++ b/incuna-sass/helpers/_link.sass
@@ -1,17 +1,27 @@
-%link
+// Mixin to quickly add / remove default styles to links
+@mixin link($type: default)
     cursor: pointer
-    text-decoration: underline
-    &:hover
+    @if $type = default
+        text-decoration: underline
+        &:hover
+            text-decoration: none
+    @if $type = reverse
         text-decoration: none
+        &:hover
+            text-decoration: underline
+    @if $type = blank
+        text-decoration: none
+        &:hover
+            text-decoration: none
+
+%link
+    @include link
+    @warn "@extend %link helpers are deprecated, please use @include link() instead"
 
 %link-reverse
-    cursor: pointer
-    text-decoration: none
-    &:hover
-        text-decoration: underline
+    @include link(reverse)
+    @warn "@extend %link helpers are deprecated, please use @include link() instead"
 
 %link-blank
-    cursor: pointer
-    text-decoration: none
-    &:hover
-        text-decoration: none
+    @include link(blank)
+    @warn "@extend %link helpers are deprecated, please use @include link() instead"

--- a/incuna-sass/helpers/_overflow-scroll.sass
+++ b/incuna-sass/helpers/_overflow-scroll.sass
@@ -1,3 +1,8 @@
-%overflow-scroll
+// Set an element to scroll content that does not
+// fit within it's dimensions
+@mixin overflow-scroll
     overflow: auto
     -webkit-overflow-scrolling: touch
+
+%overflow-scroll
+    @include overflow-scroll

--- a/incuna-sass/helpers/_visually-hidden.sass
+++ b/incuna-sass/helpers/_visually-hidden.sass
@@ -1,9 +1,16 @@
-%visually-hidden
+// Can be used to visually hide content on screen
+// in a way that is accessibility friendly
+// Preferable to display: none on elements that
+// will always be hidden
+
+@mixin visually-hidden
     border: 0
-    clip: rect(0 0 0 0)
     height: 1px
     margin: -1px
     overflow: hidden
     padding: 0
     position: absolute
     width: 1px
+
+%visually-hidden
+    @include visually-hidden

--- a/incuna-sass/legacy/_vertical-center.sass
+++ b/incuna-sass/legacy/_vertical-center.sass
@@ -1,6 +1,6 @@
-// @extend %vertical-center on the parent of the target
+// @include vertical-center on the parent of the target
 // inline-block and font-size on the target
-%vertical-center
+%legacy-vertical-center
     font:
         size: 0
     $selector: "&:before"


### PR DESCRIPTION
to reduce problems with overwriting @extends. Remove leftover legacy file names from imports files. Move vertical-center mixin to legacy folder.

I wasn't really sure what to do to update the vertical-center helper because I'm not entirely sure how it works or if it can be updated sensibly. 

@incuna/frontend please review