### PR TITLE
Fix bug: Line-height issue in [type='file']

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [upcoming 5.3.2]
+
+* Fix bug with line-height of input[type="file"]
+
 # 5.3.1
 
 * Remove @warn from link helpers because they are printed even when the extensions aren't being used (and it's annoying)

--- a/incuna-sass/components/_forms.sass
+++ b/incuna-sass/components/_forms.sass
@@ -145,8 +145,7 @@ input[type="submit"]
     height: auto
 
 // Set the height of select and file controls to match text inputs
-select,
-input[type="file"]
+select
     // In IE7, the height of the select element cannot be changed by height, only font-size
     height: rem(28px)
     line-height: rem(28px)


### PR DESCRIPTION
@incuna/frontend please merge

It looks like `input[type="file"]` got there accidentally. 

It's sass is in the same file, here:
https://github.com/incuna/incuna-sass/blob/fbf074cf2171e43485148dd8a95dd4f79cb227d3/incuna-sass/components/_forms.sass#L133