### PR TITLE
Make sure the node module path is reported correctly

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -1,14 +1,21 @@
+// This index module is returned by default when this package is required
+
+// Node module imports
 var path = require('path');
-var moduleEntryPoint = require.resolve('incuna-sass');
 
-var moduleDir = path.dirname(moduleEntryPoint);
-
+// Function returns absolute system path to location that module is installed.
+// This is useful for referencing the files within this package in grunt tasks
+// Uses a technique copied from node-bourbon
 function includePaths() {
-  return [moduleDir];
+    var moduleEntryPoint = require.resolve('incuna-sass');
+    var entrypointDir = path.dirname(moduleEntryPoint);
+    // Module resolves to the main entry point - e.g. node/index.js, so we go up a 
+    //  level to get the main module root path
+    var moduleDir = path.join(entrypointDir, '../');
+    return [moduleDir];
 }
 
 module.exports = {
-
-  includePaths: includePaths()
-
+    // run modulePath() function immediately and return result as exported value
+    includePaths: includePaths()
 };


### PR DESCRIPTION
Without this, the module paths was resolved to [module location]/node due to the `"main"` entry in `package.json`