### PR TITLE
add hover-states to variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Upcoming
+
+* Add hover state variables
+
 # 5.6.0
 
 * Add svgstore icon sass to incuna normalise

--- a/incuna-sass/_variables.sass
+++ b/incuna-sass/_variables.sass
@@ -23,3 +23,6 @@ $site-padding: 25px !default
     // normalise.sass
     // font-face.sass
 $project: none !default
+
+// Helpful variables
+$hover-states: '&:hover, &:active, &:focus'


### PR DESCRIPTION
@incuna/frontend we have this variable in incuna-transitions, but not in incuna-sass. We need it as we often add it manually to projects. It's handy in incuna-transitions, but isn't transition-dependant, it's just a shorthand all round. If you think this is not the best file, let me know? Seemed like the right place, even though the other variables here are suggested as being changable.